### PR TITLE
Fix volume slider calculation bugs in PlayBar component

### DIFF
--- a/frontend/components/play_bar/play_bar.jsx
+++ b/frontend/components/play_bar/play_bar.jsx
@@ -252,9 +252,7 @@ class PlayBar extends React.Component {
 
   getVolumeSliderProgress() {
     const { volume } = this.props.playback;
-    const handleHeightOffset = 10;
-
-    let result = Math.round(100 * volume / MAX_VOL_SLIDER_HEIGHT) - handleHeightOffset;
+    let result = volume;
 
     if (result < 0) { result = 0; }
     if (result > MAX_VOL_SLIDER_HEIGHT) { result = MAX_VOL_SLIDER_HEIGHT; }
@@ -265,7 +263,7 @@ class PlayBar extends React.Component {
   getVolumeHandleTopPos() {
     const { volume } = this.props.playback;
 
-    let result = Math.round(100 * (100 - volume) / MAX_VOL_SLIDER_HEIGHT);
+    let result = 100 - volume;
 
     if (result < 10) { result = 10; }
     if (result > MAX_VOL_SLIDER_HEIGHT + 2) { result = MAX_VOL_SLIDER_HEIGHT + 2; }

--- a/frontend/components/play_bar/playback.jsx
+++ b/frontend/components/play_bar/playback.jsx
@@ -34,7 +34,7 @@ class Playback extends React.Component {
       case RECEIVE_POSITION:
       case RECEIVE_DURATION:
       case RECEIVE_NEW_PLAYBACK_SONGS:
-      case RECEIVE_VOLUME:
+      // case RECEIVE_VOLUME:
       case TOGGLE_SHUFFLE:
       case TOGGLE_LOOP:
       case UPDATE_QUEUE:


### PR DESCRIPTION
- Fixed getVolumeSliderProgress(): Changed from incorrect division by MAX_VOL_SLIDER_HEIGHT to direct use of volume percentage
- Fixed getVolumeHandleTopPos(): Changed from incorrect division formula to proper inverse calculation of volume, now properly mirrors the progress bar
- Both methods now correctly scale the visual slider components to match the actual volume value (0-100)